### PR TITLE
added a name for the conda environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ printf "\n    ${GREEN}Setting up conda environment...${NC}\n\n"
 chmod +x $PATH_TO_PSEUDOFINDER/pseudofinder.py
 
 ## creating environment and installing dependencies
-conda env create --file $PATH_TO_PSEUDOFINDER/modules/environment.yml
+conda env create --name pseudofinder --file $PATH_TO_PSEUDOFINDER/modules/environment.yml
 
 ## activating environment
 source activate pseudofinder


### PR DESCRIPTION
Without this change, the environment is unnamed. This means that `conda activate pseudofinder` does not work and instead `conda activate -p <path to environment>` is required. My proposed change resolves this issue and allows `conda activate pseudofinder` to work.